### PR TITLE
Feat: Creating conditional for relationships filter

### DIFF
--- a/exa/Support/Datatable.php
+++ b/exa/Support/Datatable.php
@@ -45,7 +45,14 @@ final readonly class Datatable
 
         return $builder->where(function (Builder $query) use ($dto, $fieldsToSearch) {
             foreach ($fieldsToSearch as $field) {
-                $query->orwhere($field, 'LIKE', "%{$dto->search}%");
+                if (str_contains($field, '.')) {
+                    [$relation, $column] = explode('.', $field);
+                    $query->orWhereHas($relation, function ($q) use ($dto, $column) {
+                        $q->where($column, 'LIKE', "%{$dto->search}%");
+                    });
+                } else {
+                    $query->orWhere($field, 'LIKE', "%{$dto->search}%");
+                }
             }
         });
     }

--- a/exa/Support/Datatable.php
+++ b/exa/Support/Datatable.php
@@ -47,12 +47,13 @@ final readonly class Datatable
             foreach ($fieldsToSearch as $field) {
                 if (str_contains($field, '.')) {
                     [$relation, $column] = explode('.', $field);
-                    $query->orWhereHas($relation, function ($q) use ($dto, $column) {
+                    $query->orWhereHas($relation, function (Builder $q) use ($dto, $column) {
                         $q->where($column, 'LIKE', "%{$dto->search}%");
                     });
-                } else {
-                    $query->orWhere($field, 'LIKE', "%{$dto->search}%");
+
+                    continue;
                 }
+                $query->orWhere($field, 'LIKE', "%{$dto->search}%");
             }
         });
     }


### PR DESCRIPTION
With this PR, it will be possible to apply filters not only to the main table, but also to its relationships.

```
$query = Datatable::applyFilter($query, $datatableDTO, [
  'field_a', 'field_b', 'relationship.field_a', 'relationship.field_b'
]);
``